### PR TITLE
chore: remove pass_filenames: false from pre-commit hooks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -10,7 +10,6 @@ repos:
       language: python
       types: [python]
       require_serial: true
-      pass_filenames: false
       additional_dependencies: ['black==23.3.0']
     - id: ruff
       name: ruff
@@ -18,7 +17,6 @@ repos:
       language: python
       types: [python]
       require_serial: true
-      pass_filenames: false
       additional_dependencies: ['ruff==0.0.272']
 
   - repo: https://github.com/pre-commit/pre-commit-hooks


### PR DESCRIPTION
- Black and ruff need filenames to work correctly
- Removing this setting allows the hooks to receive file paths
- Fixes 'One of SRC or code is required' and 'Expected at least one path' errors