### PR TITLE
fix: allow empty folders to be opened without crashing

### DIFF
--- a/sacro/models.py
+++ b/sacro/models.py
@@ -115,7 +115,6 @@ class ACROOutputs(dict):
         try:
             assert "version" in self.raw_metadata
             assert "results" in self.raw_metadata
-            assert len(self.raw_metadata["results"]) > 0
             for result in self.raw_metadata["results"].values():
                 assert "files" in result
                 assert len(result["files"]) > 0
@@ -146,6 +145,7 @@ class ACROOutputs(dict):
 
         # add and check checksum data, and transform cell data to more useful format
         checksums_dir = self.path.parent / "checksums"
+        checksums_dir.mkdir(exist_ok=True)
         for output, metadata in self.items():
             for filedata in metadata["files"]:
                 # checksums

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -44,7 +44,6 @@ def test_outputs_annotation_checksum_failed(test_outputs):
     [
         {},
         {"version": "1"},
-        {"version": "1", "results": {}},
         {"version": "1", "results": {"name": {"files": []}}},
         {"version": "1", "results": {"name": {"notfiles": "foo"}}},
     ],


### PR DESCRIPTION
- Remove assertion requiring non-empty results in ACRO Outputs validation
- Ensure checksums directory exists before accessing it in annotate()
- Updated test to reflect new behavior allowing empty results