### PR TITLE
feat: implement reviewer text writing to results.json 

### DIFF
--- a/sacro/views.py
+++ b/sacro/views.py
@@ -31,6 +31,26 @@ logger = logging.getLogger(__name__)
 REVIEWS = {}
 
 
+def _write_reviewer_text_to_results(outputs, review_data):
+    """Write reviewer text back to results.json file"""
+    try:
+        reviewer_text = zipfile.get_summary(review_data, outputs)
+
+        results_data = outputs.raw_metadata.copy()
+
+        results_data["reviewer_summary"] = reviewer_text
+        results_data["review_timestamp"] = datetime.now().isoformat()
+        results_data["reviewer"] = getpass.getuser()
+
+        with open(outputs.path, "w") as f:
+            json.dump(results_data, f, indent=2)
+
+        logger.info(f"Reviewer text written to {outputs.path}")
+
+    except Exception as e:
+        logger.error(f"Error writing reviewer text to results.json: {e}")
+
+
 def format_mime_type(mime_type):
     """
     Convert MIME types to user-friendly display names.
@@ -196,11 +216,13 @@ def review_create(request):
     if unrecognized_outputs:
         return HttpResponseBadRequest(f"invalid output names: {unrecognized_outputs}")
 
-    REVIEWS["current"] = {
+    review_data = {
         "comment": comment,
         "decisions": review,
         "path": outputs.path,
     }
+    REVIEWS["current"] = review_data
+    _write_reviewer_text_to_results(outputs, review_data)
 
     return redirect("review-detail", pk="current")
 

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -207,8 +207,11 @@ def test_review_create_no_review_data(test_outputs):
     assert b"no review data submitted" in response.content
 
 
-def test_review_create_success(test_outputs, review_data):
-    path = urlencode({"path": test_outputs.path})
+def test_review_create_success(test_outputs, review_data, tmp_path):
+    temp_results = tmp_path / "results.json"
+    temp_results.write_text(test_outputs.path.read_text())
+
+    path = urlencode({"path": temp_results})
     request = RequestFactory().post(
         f"/?{path}", data={"comment": "test", "review": json.dumps(review_data)}
     )
@@ -217,15 +220,16 @@ def test_review_create_success(test_outputs, review_data):
 
     assert response.status_code == 302, response.content
     assert response.url == reverse("review-detail", kwargs={"pk": "current"})
-    assert views.REVIEWS["current"] == {
-        "comment": "test",
-        "decisions": review_data,
-        "path": test_outputs.path,
-    }
-    # check comments
+
+    assert views.REVIEWS["current"]["comment"] == "test"
+    assert views.REVIEWS["current"]["path"] == temp_results
+
     review = views.REVIEWS["current"]["decisions"]
     first = list(review)[0]
     assert review[first]["comment"] == "comment with ' and 😀"
+
+    updated_data = json.loads(temp_results.read_text())
+    assert "reviewer_summary" in updated_data
 
 
 def test_review_create_html_entities(test_outputs, review_data):
@@ -1373,3 +1377,56 @@ def test_researcher_load_session_not_found_cleanup(client, tmp_path):
     # Test that the file exists for setup only - the actual coverage
     # of the if block in the view is handled elsewhere
     assert draft_path.exists()
+
+
+def test_reviewer_text_written_to_results(test_outputs, tmp_path):
+    """Test that reviewer text is written to results.json when review is created"""
+    import tempfile
+
+    with tempfile.TemporaryDirectory() as temp_dir:
+        temp_path = Path(temp_dir)
+        results_path = temp_path / "results.json"
+
+        sample_data = {
+            "version": "0.4.0",
+            "results": {
+                "test_output": {
+                    "uid": "test_output",
+                    "status": "review",
+                    "type": "custom",
+                    "properties": {},
+                    "files": [{"name": "test.csv"}],
+                    "outcome": {},
+                    "command": "custom",
+                    "summary": "review",
+                    "timestamp": "2026-02-03T14:34:20.503907",
+                    "comments": ["Test output"],
+                    "exception": "",
+                }
+            },
+        }
+
+        with open(results_path, "w") as f:
+            json.dump(sample_data, f, indent=2)
+
+        review_data = {
+            "comment": "Overall review comment",
+            "decisions": {
+                "test_output": {"state": True, "comment": "Approved with comment"}
+            },
+            "path": results_path,
+        }
+
+        outputs = models.ACROOutputs(results_path)
+        views._write_reviewer_text_to_results(outputs, review_data)
+
+        with open(results_path) as f:
+            updated_data = json.load(f)
+
+        assert "reviewer_summary" in updated_data
+        assert "review_timestamp" in updated_data
+        assert "reviewer" in updated_data
+
+        reviewer_text = updated_data["reviewer_summary"]
+        assert "Overall review comment" in reviewer_text
+        assert "test_output" in reviewer_text


### PR DESCRIPTION
- Writes reviewer summary text back to results.json
- Stores all data in a reviewer_summary field in the results.json file
- Validates that reviewer text is properly written to results.json
-Records the reviewer username using getpass.getuser()