### PR TITLE
feat: include redacted results.json in approved outputs

### DIFF
--- a/sacro/adapters/zipfile.py
+++ b/sacro/adapters/zipfile.py
@@ -1,4 +1,6 @@
+import copy
 import io
+import json
 import logging
 import zipfile
 
@@ -11,7 +13,7 @@ logger = logging.getLogger(__name__)
 def get_summary(review, outputs):
     # add ACRO status to output decisions
     for name, data in review["decisions"].items():
-        review["decisions"][name]["acro_status"] = outputs[name].get(
+        review["decisions"][name]["acro_status"] = outputs.get(name, {}).get(
             "status", "Unknown"
         )
     return render_to_string("summary.txt", context={"review": review})
@@ -22,14 +24,37 @@ def create(outputs, review, approved_outputs):
     with zipfile.ZipFile(in_memory_zf, "w") as zip_obj:
         missing = []
 
+        redacted_metadata = copy.deepcopy(outputs.raw_metadata)
+        results = redacted_metadata.get("results", {})
+
+        to_remove = [k for k in results if k not in approved_outputs]
+        for k in to_remove:
+            del results[k]
+
+        for name in approved_outputs:
+            if name in results:
+                decision = review["decisions"].get(name, {})
+                comment = decision.get("comment")
+                if comment:
+                    if "comments" not in results[name]:
+                        results[name]["comments"] = []
+                    results[name]["comments"].append(f"Output Checker: {comment}")
+
+                results[name]["status"] = "approved"
+
+        zip_obj.writestr("results.json", json.dumps(redacted_metadata, indent=2))
+
         # add approved files
         for output in approved_outputs:
+            if output not in outputs:
+                continue
+
             for filedata in outputs[output]["files"]:
                 path = outputs.get_file_path(output, filedata["name"])
                 if path.exists():
                     zip_obj.write(path, arcname=path.name)
                 else:
-                    logger.warning("{path} does not exist. Excluding from zipfile")
+                    logger.warning(f"{path} does not exist. Excluding from zipfile")
                     missing.append(str(path))
 
         if missing:


### PR DESCRIPTION
Add a redacted version of the session metadata to the ZIP file generated when the output checker downloads approved outputs. The redacted results.json:
- Contains only approved outputs (rejected items are removed)
- Updates the status of each output to 'approved'
- Appends the output checker's review comments