### PR TITLE
fix: sync folder contents with results.json on researcher view save

### DIFF
--- a/sacro/views.py
+++ b/sacro/views.py
@@ -620,19 +620,16 @@ def researcher_delete_output(request):
 
         if output_name in session_data["results"]:
             output_data = session_data["results"][output_name]
-            if "files" in output_data:
-                for file_info in output_data["files"]:
-                    filename = file_info.get("name")
-                    if filename:
-                        file_path = outputs.path.parent / filename
-                        if file_path.exists():
-                            file_path.unlink()
-
-                        checksum_path = (
-                            outputs.path.parent / "checksums" / f"{filename}.txt"
-                        )
-                        if checksum_path.exists():
-                            checksum_path.unlink()
+            for file_info in output_data.get("files", []):
+                filename = file_info.get("name")
+                if not filename:
+                    continue
+                file_path = outputs.path.parent / filename
+                if file_path.exists():
+                    file_path.unlink()
+                checksum_path = outputs.path.parent / "checksums" / f"{filename}.txt"
+                if checksum_path.exists():
+                    checksum_path.unlink()
             del session_data["results"][output_name]
         else:
             return JsonResponse(


### PR DESCRIPTION
- Added logic to researcher_delete_output so all files listed under the output's files entry are deleted
- Corresponding checksum files in checksums/<filename>.txt are also removed
- Ensures the folder contents stay in sync with the session state