### PR TITLE
fix: add CSRF protection and prevent data loss on output edits

### DIFF
--- a/assets/src/scripts/researcher.js
+++ b/assets/src/scripts/researcher.js
@@ -752,7 +752,9 @@ document.addEventListener("DOMContentLoaded", () => {
           .then((result) => {
             if (result.success) {
               sessionData.results[newName] = result.output_data || sessionData.results[currentEditOutput];
-              delete sessionData.results[currentEditOutput];
+              if (newName !== currentEditOutput) {
+                delete sessionData.results[currentEditOutput];
+              }
 
               const item = document.querySelector(`li[data-output-name="${currentEditOutput}"]`);
               if (item) {

--- a/sacro/views.py
+++ b/sacro/views.py
@@ -19,6 +19,7 @@ from django.shortcuts import redirect
 from django.template.loader import render_to_string
 from django.template.response import TemplateResponse
 from django.urls import reverse
+from django.views.decorators.csrf import ensure_csrf_cookie
 from django.views.decorators.http import require_GET, require_POST
 
 from sacro import errors, models, utils
@@ -298,6 +299,7 @@ def role_selection(request):
     return TemplateResponse(request, "role_selection.html", context={"path": path})
 
 
+@ensure_csrf_cookie
 @require_GET
 def researcher_index(request):
     """


### PR DESCRIPTION
## Description

### Problems
The researcher interface was experiencing three critical issues preventing file uploads and session management:

1. **CSRF Token Missing**: POST requests from the client-side JavaScript GUI were being rejected due to missing CSRF token validation
2. **Data Loss When Editing Output Metadata**: When editing an output without changing its name, the application would delete the output's data from memory, causing a `TypeError: Cannot read property of undefined` and permanently corrupting the results.json file on the next save

### Causes

#### 1. Missing `@ensure_csrf_cookie` Decorator
The `researcher_index` view was missing the `@ensure_csrf_cookie` decorator. Without this decorator:
- The CSRF token cookie wasn't being set on the initial GET request
- The client-side JavaScript couldn't retrieve the token for POST requests
- Django's CSRF middleware rejected all POST requests from the GUI

#### 2. Incorrect Output Deletion Logic in Edit Handler
In `assets/src/scripts/researcher.js`, the `setupOutputManagement()` function had a critical flaw in the edit output handler. The code was deleting the old record after editing:
```javascript
if (newName !== currentEditOutput && sessionData.results[newName]) {
delete sessionData.results[currentEditOutput]; 
}
