### PR TITLE
chore: add PyPI workflow and build configuration

### DIFF
--- a/.github/workflows/pypi.yml
+++ b/.github/workflows/pypi.yml
@@ -1,0 +1,79 @@
+---
+name: PyPI Publish
+
+on:
+  workflow_dispatch:
+  release:
+    types:
+    - published
+
+jobs:
+  build:
+    runs-on: ubuntu-22.04
+
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: "opensafely-core/setup-action@v1"
+        with:
+          python-version: "3.10"
+
+      - uses: actions/setup-node@v6
+        with:
+          node-version-file: ".node-version"
+          cache: "npm"
+
+      - name: Build JS assets
+        run: |
+          npm ci
+          npm run build
+
+      - name: Collect static files
+        env:
+          SECRET_KEY: placeholder-for-collectstatic
+          DJANGO_SETTINGS_MODULE: sacro.settings
+        run: |
+          pip install -r requirements.prod.txt
+          python manage.py collectstatic --noinput
+
+      - name: Build
+        run: pipx run build
+
+      - uses: actions/upload-artifact@v7
+        with:
+          name: build-artifacts
+          path: dist/*
+
+  upload:
+    runs-on: ubuntu-22.04
+    if: github.event_name == 'release' && github.event.action == 'published'
+
+    needs: [build]
+
+    environment:
+      name: pypi
+      url: https://pypi.org/p/sacro
+
+    permissions:
+      id-token: write
+      contents: read
+      attestations: write
+
+    steps:
+      - uses: actions/download-artifact@v8
+        with:
+          pattern: build-*
+          path: dist
+          merge-multiple: true
+
+      - name: Attest
+        uses: actions/attest-build-provenance@v4
+        with:
+          subject-path: "dist/*"
+
+      - name: Publish on PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          packages-dir: dist/
+          # repository-url: https://test.pypi.org/legacy/
+...

--- a/hatch_build.py
+++ b/hatch_build.py
@@ -1,0 +1,37 @@
+import os
+import shutil
+import subprocess
+import sys
+
+from hatchling.builders.hooks.plugin.interface import BuildHookInterface
+
+
+class CustomBuildHook(BuildHookInterface):
+    def initialize(self, version, build_data):
+        if self.target_name not in ["wheel", "sdist"]:
+            return
+
+        source_dir = os.path.join(self.root, "assets", "dist")
+        dest_dir = os.path.join(self.root, "sacro", "static", "sacro")
+
+        # Skip npm build if assets already exist (e.g. during editable/dev install)
+        if os.path.exists(source_dir) and os.listdir(source_dir):
+            print("Frontend assets already built, skipping npm build...", file=sys.stderr)
+        else:
+            print("Building frontend assets...", file=sys.stderr)
+
+            if not shutil.which("npm"):
+                print("Error: 'npm' is not installed or not in PATH.", file=sys.stderr)
+                sys.exit(1)
+
+            print("Installing npm dependencies...", file=sys.stderr)
+            subprocess.check_call("npm install", shell=True)
+
+            print("Compiling assets with npm...", file=sys.stderr)
+            subprocess.check_call("npm run build", shell=True)
+
+        if os.path.exists(dest_dir):
+            shutil.rmtree(dest_dir)
+
+        print(f"Copying assets from {source_dir} to {dest_dir}...", file=sys.stderr)
+        shutil.copytree(source_dir, dest_dir, dirs_exist_ok=True)

--- a/hatch_build.py
+++ b/hatch_build.py
@@ -16,12 +16,18 @@ class CustomBuildHook(BuildHookInterface):
 
         # Skip npm build if assets already exist (e.g. during editable/dev install)
         if os.path.exists(source_dir) and os.listdir(source_dir):
-            print("Frontend assets already built, skipping npm build...", file=sys.stderr)
+            print(
+                "Frontend assets already built, skipping npm build...",
+                file=sys.stderr,
+            )
         else:
             print("Building frontend assets...", file=sys.stderr)
 
             if not shutil.which("npm"):
-                print("Error: 'npm' is not installed or not in PATH.", file=sys.stderr)
+                print(
+                    "Error: 'npm' is not installed or not in PATH.",
+                    file=sys.stderr,
+                )
                 sys.exit(1)
 
             print("Installing npm dependencies...", file=sys.stderr)
@@ -33,5 +39,8 @@ class CustomBuildHook(BuildHookInterface):
         if os.path.exists(dest_dir):
             shutil.rmtree(dest_dir)
 
-        print(f"Copying assets from {source_dir} to {dest_dir}...", file=sys.stderr)
+        print(
+            f"Copying assets from {source_dir} to {dest_dir}...",
+            file=sys.stderr,
+        )
         shutil.copytree(source_dir, dest_dir, dirs_exist_ok=True)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ requires = ["hatchling", "hatch-requirements-txt"]
 build-backend = "hatchling.build"
 
 [project]
-name = "sacro"
+name = "Sacro"
 version = "0.1.0"
 description = "A viewer for research outputs produced using the ACRO tools"
 readme = "README.md"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,45 @@
+[build-system]
+requires = ["hatchling", "hatch-requirements-txt"]
+build-backend = "hatchling.build"
+
+[project]
+name = "sacro"
+version = "0.1.0"
+description = "A viewer for research outputs produced using the ACRO tools"
+readme = "README.md"
+license = { text = "MIT" }
+requires-python = ">=3.10"
+dynamic = ["dependencies"]
+maintainers = [
+    {name = "Jim Smith", email = "james.smith@uwe.ac.uk"}
+]
+keywords = [
+    "output-viewer",
+    "data-privacy",
+    "data-protection",
+    "privacy",
+    "privacy-tools",
+    "statistical-disclosure-control",
+    "statistical-software",
+]
+
+[tool.hatch.metadata.hooks.requirements_txt]
+files = ["requirements.prod.in"]
+
+[tool.hatch.build.targets.wheel]
+packages = ["sacro"]
+artifacts = ["sacro/static"]
+
+[tool.hatch.build.hooks.custom]
+path = "hatch_build.py"
+
+[project.scripts]
+sacroviewer = "sacro.__main__:main"
+
+[project.urls]
+"Homepage" = "https://github.com/AI-SDC/SACRO-Viewer"
+"Bug Tracker" = "https://github.com/AI-SDC/SACRO-Viewer/issues"
+
 [tool.coverage.run]
 branch = true
 dynamic_context = "test_function"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ requires = ["hatchling", "hatch-requirements-txt"]
 build-backend = "hatchling.build"
 
 [project]
-name = "Sacro"
+name = "Sacroviewer"
 version = "0.1.0"
 description = "A viewer for research outputs produced using the ACRO tools"
 readme = "README.md"

--- a/sacro/__main__.py
+++ b/sacro/__main__.py
@@ -3,8 +3,6 @@ import os
 
 import uvicorn
 
-from sacro.asgi import application
-
 
 logger = logging.getLogger(__name__)
 logging.basicConfig(level=logging.INFO)
@@ -13,6 +11,10 @@ PORT = int(os.environ.get("PORT", "8000"))
 
 
 def main():
+    os.environ.setdefault("DJANGO_SETTINGS_MODULE", "sacro.settings")
+
+    from sacro.asgi import application
+
     return uvicorn.run(application, host="127.0.0.1", port=PORT)
 
 

--- a/sacro/settings.py
+++ b/sacro/settings.py
@@ -176,7 +176,7 @@ LOCAL_DIST_DIR = BASE_DIR / "assets" / "dist"
 if LOCAL_DIST_DIR.exists():
     DJANGO_VITE_ASSETS_PATH = LOCAL_DIST_DIR
     DJANGO_VITE_STATIC_URL_PREFIX = ""
-else:
+else: # pragma: no cover
     DJANGO_VITE_ASSETS_PATH = DIST_DIR
     DJANGO_VITE_STATIC_URL_PREFIX = "sacro"
 

--- a/sacro/settings.py
+++ b/sacro/settings.py
@@ -12,6 +12,7 @@ https://docs.djangoproject.com/en/4.1/ref/settings/
 import os
 from pathlib import Path
 
+from django.core.management.utils import get_random_secret_key
 from environs import Env
 
 from .logging import logging_config_dict
@@ -28,7 +29,7 @@ BASE_DIR = Path(__file__).resolve().parent.parent
 # See https://docs.djangoproject.com/en/4.1/howto/deployment/checklist/
 
 # SECURITY WARNING: keep the secret key used in production secret!
-SECRET_KEY = env.str("SECRET_KEY")
+SECRET_KEY = env.str("SECRET_KEY", get_random_secret_key())
 
 # SECURITY WARNING: don't run with debug turned on in production!
 DEBUG = env.bool("DEBUG", default=False)
@@ -165,10 +166,23 @@ STATICFILES_DIRS = [
 STATIC_ROOT = env.path("STATIC_ROOT", default=BASE_DIR / "sacro/staticfiles")
 STATIC_URL = "/static/"
 
-DJANGO_VITE_ASSETS_PATH = BASE_DIR / "assets" / "dist"
+# Assets location within the package (used when installed via pip)
+PKG_DIR = Path(__file__).resolve().parent
+DIST_DIR = PKG_DIR / "static" / "sacro"
+
+# Local development assets
+LOCAL_DIST_DIR = BASE_DIR / "assets" / "dist"
+
+if LOCAL_DIST_DIR.exists():
+    DJANGO_VITE_ASSETS_PATH = LOCAL_DIST_DIR
+    DJANGO_VITE_STATIC_URL_PREFIX = ""
+else:
+    DJANGO_VITE_ASSETS_PATH = DIST_DIR
+    DJANGO_VITE_STATIC_URL_PREFIX = "sacro"
+
 DJANGO_VITE_DEV_MODE = env.bool("DJANGO_VITE_DEV_MODE", default=False)
 DJANGO_VITE_DEV_SERVER_PORT = 5173
-DJANGO_VITE_MANIFEST_PATH = STATIC_ROOT / "manifest.json"
+DJANGO_VITE_MANIFEST_PATH = DJANGO_VITE_ASSETS_PATH / "manifest.json"
 
 # Insert Whitenoise Middleware.
 STATICFILES_STORAGE = "whitenoise.storage.CompressedStaticFilesStorage"

--- a/sacro/settings.py
+++ b/sacro/settings.py
@@ -176,7 +176,7 @@ LOCAL_DIST_DIR = BASE_DIR / "assets" / "dist"
 if LOCAL_DIST_DIR.exists():
     DJANGO_VITE_ASSETS_PATH = LOCAL_DIST_DIR
     DJANGO_VITE_STATIC_URL_PREFIX = ""
-else: # pragma: no cover
+else:  # pragma: no cover
     DJANGO_VITE_ASSETS_PATH = DIST_DIR
     DJANGO_VITE_STATIC_URL_PREFIX = "sacro"
 


### PR DESCRIPTION
Closes #348

This PR makes SACRO-Viewer installable and runnable via pip by:
- Setting up `hatch` as the build backend
- Configuring package metadata in `pyproject.toml`
- Creating automated build and publishing workflows
- Adding a CLI entrypoint (`sacroviewer` command)

## Changes

### Files Changed
- `pyproject.toml` - Package metadata, build configuration, dependencies
- `hatch_build.py` - Custom build hook for frontend asset bundling
- `.github/workflows/pypi.yml` - Automated PyPI publishing workflow
- `requirements.prod.in` - Production dependencies

### Key Features
- Package installable via: `pip install sacro`
- CLI entrypoint: `sacroviewer` command
- Automated frontend asset bundling during build
- Django static files collection included
- Automated PyPI publishing via GitHub Actions Trusted Publishers

## Testing

### Local Testing
```bash

# Install locally in editable mode
pip install -e .

# Verify CLI works
sacroviewer