### PR TITLE
fix: electron app internal error

### DIFF
--- a/justfile
+++ b/justfile
@@ -153,7 +153,11 @@ run: devenv collectstatic test-outputs
     $BIN/python manage.py runserver
 
 # Build python application
-build: collectstatic
+build: assets-build
+    #!/usr/bin/env bash
+    set -eu
+    mkdir -p sacro/static/sacro
+    cp -r assets/dist/* sacro/static/sacro/
     $BIN/pyoxidizer build --release
 
 # Install the Node.js dependencies

--- a/pyoxidizer.bzl
+++ b/pyoxidizer.bzl
@@ -276,6 +276,14 @@ def make_exe():
         packages=["sacro",],
     ))
 
+    # Add static files from sacro/static directory
+    for resource in exe.read_package_root(
+        path="sacro",
+        packages=["static"],
+    ):
+        resource.add_location = "filesystem-relative:lib"
+        exe.add_python_resource(resource)
+
     # Discover Python files from a virtualenv and add them to our embedded
     # context.
     #exe.add_python_resources(exe.read_virtualenv(path="/path/to/venv"))

--- a/sacro-app/src/find-app-path.js
+++ b/sacro-app/src/find-app-path.js
@@ -27,7 +27,7 @@ const findAppPath = () => {
 
   if (!getPath) {
     console.error("Could not find sacro build, checked:", fileLocations);
-    return app.quit();
+    return null;
   }
 
   return getPath;

--- a/sacro-app/src/main-menu.js
+++ b/sacro-app/src/main-menu.js
@@ -98,21 +98,30 @@ const mainMenu = (serverUrl) => {
   }
 
   let buildDate = "Not defined";
-  const buildDateFile = nodePath.join(
-    nodePath.dirname(findAppPath()),
-    "build_date.txt"
-  );
-  log.info(buildDateFile);
-  if (fs.existsSync(buildDateFile)) {
-    buildDate = fs.readFileSync(buildDateFile);
-    buildDate = `${buildDate}`.trim();
+  const appPath = findAppPath();
+  if (appPath) {
+    const buildDateFile = nodePath.join(
+      nodePath.dirname(appPath),
+      "build_date.txt"
+    );
+    log.info(buildDateFile);
+    if (fs.existsSync(buildDateFile)) {
+      buildDate = fs.readFileSync(buildDateFile);
+      buildDate = `${buildDate}`.trim();
+    }
   }
+
+  // Get the app directory to locate icon resources
+  const appDir = process.env.PORTABLE_EXECUTABLE_DIR ||
+                 nodePath.dirname(process.execPath) ||
+                 nodePath.join(__dirname, "..");
+  const iconPath = nodePath.join(appDir, "build", "icon.png");
 
   app.setAboutPanelOptions({
     applicationName: "SACRO",
     applicationVersion: `Version ${app.getVersion()} (Build ${buildDate})`,
     credits: "By OpenSAFELY",
-    iconPath: "build/icon.png",
+    iconPath: iconPath,
   });
 
   return Menu.buildFromTemplate(menuItems);


### PR DESCRIPTION
- Fix: Handle null return value in find-app-path.js when SACRO binary not found
- Fix: Add null check in main-menu.js before accessing findAppPath() result
- Fix: Update justfile build target to ensure assets are properly copied before pyoxidizer build
- Fix: Update pyoxidizer.bzl to explicitly include static files in the bundle
- Fix: Update main-menu.js to use absolute path for app icon

These changes fix the internal server error when running the built Electron app by ensuring the Vite assets (manifest.json, CSS, JS files) are properly included in the PyOxidizer bundle and can be found at runtime.